### PR TITLE
add custom event on head purchase

### DIFF
--- a/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Head.java
+++ b/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Head.java
@@ -5,12 +5,15 @@ import io.github.thatsmusic99.headsplus.api.HPPlayer;
 import io.github.thatsmusic99.headsplus.config.HeadsPlusMessagesConfig;
 import io.github.thatsmusic99.headsplus.config.headsx.HeadsPlusConfigHeadsX;
 import io.github.thatsmusic99.headsplus.config.headsx.Icon;
+import io.github.thatsmusic99.headsplus.events.HeadPurchaseEvent;
 import io.github.thatsmusic99.headsplus.locale.LocaleManager;
 import io.github.thatsmusic99.headsplus.nms.NMSManager;
 import io.github.thatsmusic99.headsplus.util.AdventCManager;
 import io.github.thatsmusic99.headsplus.util.InventoryManager;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -129,18 +132,14 @@ public class Head extends ItemStack implements Icon {
             String fail = hpc.getString("cmd-fail");
             if (er.transactionSuccess()) {
                 p.sendMessage(success);
-                p.getInventory().addItem(HeadsPlus.getInstance().getNMS().removeIcon(e.getCurrentItem()));
-                e.setCancelled(true);
-                return;
             } else {
                 p.sendMessage(fail + ": " + er.errorMessage);
                 e.setCancelled(true);
                 return;
             }
         }
-        ItemStack is = e.getCurrentItem();
-        is = nms.removeIcon(is);
-        p.getInventory().addItem(is);
+        p.getInventory().addItem(HeadsPlus.getInstance().getNMS().removeIcon(e.getCurrentItem()));
+        Bukkit.getServer().getPluginManager().callEvent(new HeadPurchaseEvent(p, e.getCurrentItem()));
         e.setCancelled(true);
     }
 

--- a/main/java/io/github/thatsmusic99/headsplus/events/HeadPurchaseEvent.java
+++ b/main/java/io/github/thatsmusic99/headsplus/events/HeadPurchaseEvent.java
@@ -1,0 +1,48 @@
+package io.github.thatsmusic99.headsplus.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class HeadPurchaseEvent extends Event implements Cancellable {
+
+	private final Player player;
+	private final ItemStack itemStack;
+	private boolean cancelled = false;
+
+    public HeadPurchaseEvent(Player player, ItemStack itemStack) {
+        this.player = player;
+        this.itemStack = itemStack;
+    }
+    
+	private static final HandlerList HANDLERS = new HandlerList();
+
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+	
+    public Player getPlayer() {
+        return this.player;
+    }
+    
+    public ItemStack getItemStack() {
+    	return this.itemStack;
+    }
+    
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+}


### PR DESCRIPTION
Hi, would it be possible to add a custom event which fires when a player receives or purchases a head via the ```/heads``` command interface? I think this would be quite useful.
Thanks.