### PR TITLE
fix crafting following spigot patch to catch async recipe add

### DIFF
--- a/main/java/io/github/thatsmusic99/headsplus/crafting/RecipeEnumUser.java
+++ b/main/java/io/github/thatsmusic99/headsplus/crafting/RecipeEnumUser.java
@@ -68,7 +68,7 @@ public class RecipeEnumUser {
                             i.setItemMeta(setupItemMeta(im, key));
                             i = makeSell(i, key);
 
-                            ShapelessRecipe recipe = nms.getRecipe(i, "hp" + d.name().toLowerCase() + key);
+                            ShapelessRecipe recipe = nms.getRecipe(i, "hp_" + d.name().toLowerCase() + key);
                             List<String> ingrs = new ArrayList<>();
                             for (String key2 : crafting.getStringList(key + "." + d.name() + ".ingredients")) {
                                 try {
@@ -120,7 +120,7 @@ public class RecipeEnumUser {
                             i.setType(nms.getSkull(3).getType());
                         }
                     }
-                    ShapelessRecipe recipe = nms.getRecipe(i, "hp" + key);
+                    ShapelessRecipe recipe = nms.getRecipe(i, "hp_" + key);
                     List<String> ingrs = new ArrayList<>();
                     for (String key2 : crafting.getStringList(key + ".ingredients")) {
                         try {
@@ -184,7 +184,7 @@ public class RecipeEnumUser {
                                 i.setType(nms.getSkull(3).getType());
                             }
                         }
-                        ShapelessRecipe recipe = nms.getRecipe(i, "hp" + key);
+                        ShapelessRecipe recipe = nms.getRecipe(i, "hp_" + key);
                         List<String> ingrs = new ArrayList<>();
                         if (crafting.getStringList(key + ".ingredients") != null) {
                             ingrs = crafting.getStringList(key + ".ingredients");

--- a/main/java/io/github/thatsmusic99/headsplus/listeners/JoinEvent.java
+++ b/main/java/io/github/thatsmusic99/headsplus/listeners/JoinEvent.java
@@ -56,7 +56,7 @@ public class JoinEvent implements Listener {
                 public void run() {
                     new RecipeEnumUser();
                 }
-            }.runTaskLaterAsynchronously(HeadsPlus.getInstance(), 20);
+            }.runTaskLater(HeadsPlus.getInstance(), 20);
             reloaded = true;
         }
 

--- a/main/java/io/github/thatsmusic99/headsplus/nms/v1_13_R2_NMS/v1_13_R2_NMS.java
+++ b/main/java/io/github/thatsmusic99/headsplus/nms/v1_13_R2_NMS/v1_13_R2_NMS.java
@@ -54,7 +54,7 @@ public class v1_13_R2_NMS implements NewNMSManager {
 
     @Override
     public ShapelessRecipe getRecipe(org.bukkit.inventory.ItemStack i, String name) {
-        return new ShapelessRecipe(new NamespacedKey(HeadsPlus.getInstance(), "HeadsPlus_" + name), i);
+        return new ShapelessRecipe(new NamespacedKey(HeadsPlus.getInstance(), name), i);
     }
 
     @Override


### PR DESCRIPTION
Hi,

I've noticed that crafting heads in HP has been broken on Spigot 1.13.2 since the patch below was applied on Jan 6th.

![async recipe add](https://user-images.githubusercontent.com/6975392/55201686-fb65d580-51bb-11e9-898e-0c240bd8a318.png)


This stopped the recipes being added async, and as the IllegalStateException is ignored in the code, there were no errors on joining, but none of the crafting recipes were created. So this PR is just adds the recipes synchronously.

The recipe names also seem to be over long with "headsplus:headsplus_hp....."

![2019-03-28_23 44 06](https://user-images.githubusercontent.com/6975392/55201811-ad9d9d00-51bc-11e9-9cc1-e32b3bdbb0c8.png)


Don't know what you think, but unless it has any knock on effects anywhere else, I thought it might look neater something like:

![2019-03-29_00 33 12](https://user-images.githubusercontent.com/6975392/55201872-e89fd080-51bc-11e9-91bc-f6bebf2d03f6.png)

Thanks,
Steve