### PR TITLE
Retry after 429, debug doesn't need new objects 

### DIFF
--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/HeadsPlus.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/HeadsPlus.java
@@ -195,7 +195,7 @@ public class HeadsPlus extends JavaPlugin {
             getLogger().info(hpc.getString("plugin-enabled"));
         } catch (Exception e) {
             try {
-                new DebugPrint(e, "Startup", false, null);
+                DebugPrint.createReport(e, "Startup", false, null);
             } catch (Exception ex) {
                 getLogger().severe("HeadsPlus has failed to start up correctly and can not read the config. An error report has been made in /plugins/HeadsPlus/debug");
                 try {
@@ -228,12 +228,12 @@ public class HeadsPlus extends JavaPlugin {
         try {
             favourites.save();
         } catch (IOException e) {
-            new DebugPrint(e, "Disabling (saving favourites)", false, null);
+            DebugPrint.createReport(e, "Disabling (saving favourites)", false, null);
         }
         try {
             scores.save();
         } catch (IOException e) {
-            new DebugPrint(e, "Disabling (saving scores)", false, null);
+            DebugPrint.createReport(e, "Disabling (saving scores)", false, null);
         }
         getLogger().info(hpc.getString("plugin-disabled"));
     }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/ChallengeCommand.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/ChallengeCommand.java
@@ -49,7 +49,7 @@ public class ChallengeCommand implements CommandExecutor, IHeadsPlusCommand {
                 cs.sendMessage(HeadsPlus.getInstance().getMessagesConfig().getString("disabled"));
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Command (Challenges/HPC)", true, cs);
+            DebugPrint.createReport(e, "Command (Challenges/HPC)", true, cs);
         }
         printDebugResults(tests, false);
         return true;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/Head.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/Head.java
@@ -221,7 +221,7 @@ public class Head implements CommandExecutor, IHeadsPlusCommand {
 	            sender.sendMessage(hpc.getString("no-perms"));
 	        }
         } catch (Exception e) {
-	        new DebugPrint(e, "Command (head)", true, sender);
+	        DebugPrint.createReport(e, "Command (head)", true, sender);
         }
         printDebugResults(tests, false);
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/Heads.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/Heads.java
@@ -47,7 +47,7 @@ public class Heads implements CommandExecutor, IHeadsPlusCommand {
                 cs.sendMessage(HeadsPlus.getInstance().getMessagesConfig().getString("disabled"));
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Command (heads)", true, cs);
+            DebugPrint.createReport(e, "Command (heads)", true, cs);
         }
         printDebugResults(tests, false);
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/HeadsPlusCommand.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/HeadsPlusCommand.java
@@ -65,7 +65,7 @@ public class HeadsPlusCommand implements CommandExecutor {
 
             return false;
         } catch (Exception e) {
-            new DebugPrint(e, "Command (headsplus)", true, sender);
+            DebugPrint.createReport(e, "Command (headsplus)", true, sender);
         }
 		return false;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/LeaderboardsCommand.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/LeaderboardsCommand.java
@@ -158,7 +158,7 @@ public class LeaderboardsCommand implements CommandExecutor, IHeadsPlusCommand {
                 }
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Command (leaderboard)", true, cs);
+            DebugPrint.createReport(e, "Command (leaderboard)", true, cs);
         }
         printDebugResults(tests, false);
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/MyHead.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/MyHead.java
@@ -141,7 +141,7 @@ public class MyHead implements CommandExecutor, IHeadsPlusCommand {
                 }
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Command (myhead)", true, sender);
+            DebugPrint.createReport(e, "Command (myhead)", true, sender);
         }
         printDebugResults(tests, true);
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/SellHead.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/SellHead.java
@@ -186,7 +186,7 @@ public class SellHead implements CommandExecutor, IHeadsPlusCommand {
                 sender.sendMessage("[HeadsPlus] You must be a player to run this command!");
             }
         } catch (Exception e) {
-		    new DebugPrint(e, "Command (sellhead)", true, sender);
+		    DebugPrint.createReport(e, "Command (sellhead)", true, sender);
 		}
 		printDebugResults(tests, false);
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistAdd.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistAdd.java
@@ -59,7 +59,7 @@ public class BlacklistAdd implements IHeadsPlusCommand {
 				sender.sendMessage(hpc.getString("head-added-bl").replaceAll("\\{name}", args[1]));
 			}
 		} catch (Exception e) {
-		    new DebugPrint(e, "Subcommand (blacklistadd)", true, sender);
+		    DebugPrint.createReport(e, "Subcommand (blacklistadd)", true, sender);
         }
 
         return true;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistDelete.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistDelete.java
@@ -58,7 +58,7 @@ public class BlacklistDelete implements IHeadsPlusCommand {
 	            sender.sendMessage(hpc.getString("head-a-removed-bl"));
 	        }
 	    } catch (Exception e) {
-	        new DebugPrint(e, "Subcommand (blacklistdel)", true, sender);
+	        DebugPrint.createReport(e, "Subcommand (blacklistdel)", true, sender);
 	    }
         return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistList.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistList.java
@@ -65,7 +65,7 @@ public class BlacklistList implements IHeadsPlusCommand {
             sender.sendMessage(HeadsPlusConfigTextMenu.BlacklistTranslator.translate("blacklist", "default", bl, page));
 
         } catch (Exception e) {
-	        new DebugPrint(e, "Subcommand (blacklistl)", true, sender);
+	        DebugPrint.createReport(e, "Subcommand (blacklistl)", true, sender);
         }
         return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistToggle.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistToggle.java
@@ -66,7 +66,7 @@ public class BlacklistToggle implements IHeadsPlusCommand {
 				}
 			}
 		} catch (Exception e) {
-            new DebugPrint(e, "Subcommand (blacklist)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (blacklist)", true, sender);
 		}
         return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwAdd.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwAdd.java
@@ -63,7 +63,7 @@ public class BlacklistwAdd implements IHeadsPlusCommand {
                         sender.sendMessage(hpc.getString("world-added-bl").replaceAll("\\{name}", args[1]));
                     }
                 } catch (Exception e) {
-                    new DebugPrint(e, "Subcommand (blacklistwadd)", true, sender);
+                    DebugPrint.createReport(e, "Subcommand (blacklistwadd)", true, sender);
                 }
             } else {
                 sender.sendMessage(hpc.getString("alpha-names"));

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwDelete.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwDelete.java
@@ -63,7 +63,7 @@ public class BlacklistwDelete implements IHeadsPlusCommand {
 
                     }
                 } catch (Exception e) {
-                	new DebugPrint(e, "Subcommand (blacklistwdel)", true, sender);
+                    DebugPrint.createReport(e, "Subcommand (blacklistwdel)", true, sender);
                 }
 			} else {
 				sender.sendMessage(hpc.getString("alpha-names"));

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwList.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwList.java
@@ -61,7 +61,7 @@ public class BlacklistwList implements IHeadsPlusCommand {
             sender.sendMessage(HeadsPlusConfigTextMenu.BlacklistTranslator.translate("blacklist", "world", bl, page));
 
         } catch (Exception e) {
-		    new DebugPrint(e, "Subcommand (blacklistwl)", true, sender);
+		    DebugPrint.createReport(e, "Subcommand (blacklistwl)", true, sender);
         }
 
 		return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwToggle.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/BlacklistwToggle.java
@@ -68,7 +68,7 @@ public class BlacklistwToggle implements IHeadsPlusCommand {
                 }
             }
 		} catch (Exception e) {
-            new DebugPrint(e, "Subcommand (blacklistw)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (blacklistw)", true, sender);
         }
         return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/DebugPrint.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/DebugPrint.java
@@ -34,13 +34,13 @@ import java.util.logging.Logger;
 public class DebugPrint implements IHeadsPlusCommand {
 
     // R
-    public DebugPrint(Exception e, String name, boolean command, CommandSender sender) {
+    public static void createReport(Exception e, String name, boolean command, CommandSender sender) {
         Logger log = HeadsPlus.getInstance().getLogger();
         ConfigurationSection cs = HeadsPlus.getInstance().getConfiguration().getMechanics();
         if (cs.getBoolean("debug.print-stacktraces-in-console")) {
             e.printStackTrace();
         }
-        if (command) {
+        if (command && sender != null) {
             sender.sendMessage(HeadsPlus.getInstance().getMessagesConfig().getString("cmd-fail"));
         }
 
@@ -61,6 +61,7 @@ public class DebugPrint implements IHeadsPlusCommand {
         }
 
     }
+
     public DebugPrint() {
 
     }
@@ -182,12 +183,12 @@ public class DebugPrint implements IHeadsPlusCommand {
                 try {
                     HeadsPlus.getInstance().getFavourites().save();
                 } catch (IOException e) {
-                    new DebugPrint(e, "Debug (saving favourites)", false, sender);
+                    DebugPrint.createReport(e, "Debug (saving favourites)", false, sender);
                 }
                 try {
                     HeadsPlus.getInstance().getScores().save();
                 } catch (IOException e) {
-                    new DebugPrint(e, "Debug (saving scores)", false, sender);
+                    DebugPrint.createReport(e, "Debug (saving scores)", false, sender);
                 }
                 sender.sendMessage(ChatColor.GREEN + "Data has been saved.");
             } else if (args[1].equalsIgnoreCase("transfer")) {

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/HeadInfoCommand.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/HeadInfoCommand.java
@@ -306,7 +306,7 @@ public class HeadInfoCommand implements IHeadsPlusCommand {
         } catch (IndexOutOfBoundsException ex) {
             sender.sendMessage(hpc.getString("invalid-args"));
         } catch (Exception e) {
-            new DebugPrint(e, "Head Information command", true, sender);
+            DebugPrint.createReport(e, "Head Information command", true, sender);
         }
 
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/HelpMenu.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/HelpMenu.java
@@ -81,7 +81,7 @@ public class HelpMenu implements IHeadsPlusCommand {
                 }
             }
         } catch (Exception e) {
-	        new DebugPrint(e, "Subcommand (help)", true, sender);
+	        DebugPrint.createReport(e, "Subcommand (help)", true, sender);
         }
 
         return true;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/Info.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/Info.java
@@ -35,7 +35,7 @@ public class Info implements IHeadsPlusCommand {
 		try {
 			sender.sendMessage(HeadsPlusConfigTextMenu.InfoTranslator.translate());
         } catch (Exception e) {
-		    new DebugPrint(e, "Subcommand (info)", true, sender);
+		    DebugPrint.createReport(e, "Subcommand (info)", true, sender);
         }
 		return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/MCReload.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/MCReload.java
@@ -54,7 +54,7 @@ public class MCReload implements IHeadsPlusCommand{
                 }
             }.runTaskLaterAsynchronously(HeadsPlus.getInstance(), 2);
 		} catch (Exception e) {
-		    new DebugPrint(e, "Subcommand (reload)", true, sender);
+		    DebugPrint.createReport(e, "Subcommand (reload)", true, sender);
 		}
 		return true;
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/ProfileCommand.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/ProfileCommand.java
@@ -75,7 +75,7 @@ public class ProfileCommand implements IHeadsPlusCommand {
                 }
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (profile)", true, cs);
+            DebugPrint.createReport(e, "Subcommand (profile)", true, cs);
         }
 
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistAdd.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistAdd.java
@@ -58,7 +58,7 @@ public class WhitelistAdd implements IHeadsPlusCommand {
                 sender.sendMessage(hpc.getString("head-added-wl").replaceAll("\\{name}", args[1]));
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistadd)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistadd)", true, sender);
         }
         return false;
     }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistDel.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistDel.java
@@ -58,7 +58,7 @@ public class WhitelistDel implements IHeadsPlusCommand {
                 sender.sendMessage(hpc.getString("head-a-removed-wl"));
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistdel)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistdel)", true, sender);
 
         }
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistList.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistList.java
@@ -61,7 +61,7 @@ public class WhitelistList implements IHeadsPlusCommand {
 
 
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistl)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistl)", true, sender);
         }
         return true;
     }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistToggle.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistToggle.java
@@ -71,7 +71,7 @@ public class WhitelistToggle implements IHeadsPlusCommand {
                 }
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelist)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelist)", true, sender);
         }
 
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwAdd.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwAdd.java
@@ -67,7 +67,7 @@ public class WhitelistwAdd implements IHeadsPlusCommand {
                 sender.sendMessage(ChatColor.DARK_RED + "Usage: " + ChatColor.RED + getClass().getAnnotation(CommandInfo.class).usage());
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistwadd)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistwadd)", true, sender);
         }
         return false;
     }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwDelete.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwDelete.java
@@ -66,7 +66,7 @@ public class WhitelistwDelete implements IHeadsPlusCommand {
                 sender.sendMessage(ChatColor.DARK_RED + "Usage: " + ChatColor.RED + getClass().getAnnotation(CommandInfo.class).usage());
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistwdel)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistwdel)", true, sender);
         }
 
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwList.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwList.java
@@ -60,7 +60,7 @@ public class WhitelistwList implements IHeadsPlusCommand {
             sender.sendMessage(HeadsPlusConfigTextMenu.BlacklistTranslator.translate("whitelist", "world", bl, page));
 
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistwl)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistwl)", true, sender);
         }
 
         return true;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwToggle.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/WhitelistwToggle.java
@@ -77,7 +77,7 @@ public class WhitelistwToggle implements IHeadsPlusCommand{
                 }
             }
         } catch (Exception e) {
-            new DebugPrint(e, "Subcommand (whitelistw)", true, sender);
+            DebugPrint.createReport(e, "Subcommand (whitelistw)", true, sender);
         }
 
         return false;

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/HeadsPlusConfigHeadsX.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/HeadsPlusConfigHeadsX.java
@@ -209,7 +209,7 @@ public class HeadsPlusConfigHeadsX extends ConfigSettings {
         try {
             return getConfig().getString("heads." + st[1] + ".texture");
         } catch (Exception ex) {
-            new DebugPrint(ex, "Startup (headsx.yml)", false, null);
+            DebugPrint.createReport(ex, "Startup (headsx.yml)", false, null);
             return "";
         }
     }
@@ -291,7 +291,7 @@ public class HeadsPlusConfigHeadsX extends ConfigSettings {
                 uuid = String.valueOf(resp.get("id")); // Trying to parse this as a UUID will cause an IllegalArgumentException
             }
         } catch (IOException e) {
-            new DebugPrint(e, "Retreiving UUID (addhead)", true, callback);
+            DebugPrint.createReport(e, "Retreiving UUID (addhead)", true, callback);
         }
         return uuid;
     }
@@ -376,7 +376,11 @@ public class HeadsPlusConfigHeadsX extends ConfigSettings {
                     }
                 }
             } catch (Exception ex) {
-                new DebugPrint(ex, "Retreiving profile (addhead)", true, callback);
+                if(ex instanceof IOException && ex.getMessage().contains("Server returned HTTP response code: 429 for URL")) {
+                    grabProfile(id, tries - 1, callback, forceAdd, 30 * 20);
+                } else {
+                    DebugPrint.createReport(ex, "Retreiving profile (addhead)", true, callback);
+                }
             } finally {
                 if(reader != null) {
                     try {

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Challenge.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Challenge.java
@@ -42,7 +42,7 @@ io.github.thatsmusic99.headsplus.api.Challenge challenge = HeadsPlus.getInstance
             e.setCancelled(true);
         }catch (NullPointerException ignored) {
         } catch (SQLException ex) {
-            new DebugPrint(ex, "Completing challenge", false, p);
+            DebugPrint.createReport(ex, "Completing challenge", false, p);
         }
     }
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Nav.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Nav.java
@@ -50,7 +50,7 @@ public class Nav extends ItemStack implements Icon {
         try {
             im.showPage(direction);
         } catch (Exception e1) {
-            new DebugPrint(e1, "Changing page (next)", false, p);
+            DebugPrint.createReport(e1, "Changing page (next)", false, p);
         }
     }
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Search.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/icons/Search.java
@@ -57,7 +57,7 @@ public class Search extends ItemStack implements Icon {
             }
 
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (InventoryEvent)", false, null);
+            DebugPrint.createReport(ex, "Event (InventoryEvent)", false, null);
         }
     }
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/crafting/RecipeEnumUser.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/crafting/RecipeEnumUser.java
@@ -63,7 +63,7 @@ public class RecipeEnumUser {
                     }
                 } catch (Exception e) {
                     HeadsPlus.getInstance().getLogger().severe("Error thrown creating head for " + key + ". Please check the report for details.");
-                    new DebugPrint(e, "Startup (Crafting)", false, null);
+                    DebugPrint.createReport(e, "Startup (Crafting)", false, null);
                 }
             }
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/crafting/RecipePerms.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/crafting/RecipePerms.java
@@ -64,7 +64,7 @@ public class RecipePerms implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (RecipeCheckers)", false, null);
+            DebugPrint.createReport(ex, "Event (RecipeCheckers)", false, null);
         }
 
 	}

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/DeathEvents.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/DeathEvents.java
@@ -11,17 +11,32 @@ import io.github.thatsmusic99.headsplus.config.headsx.HeadsPlusConfigHeadsX;
 import io.github.thatsmusic99.headsplus.nms.NMSManager;
 import io.github.thatsmusic99.headsplus.reflection.NBTManager;
 import io.lumine.xikage.mythicmobs.MythicMobs;
-import org.bukkit.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Llama;
+import org.bukkit.entity.Parrot;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Sheep;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitRunnable;
-
-import java.util.*;
 
 public class DeathEvents implements Listener {
 
@@ -123,7 +138,7 @@ public class DeathEvents implements Listener {
                     ItemStack head = nms.getSkullMaterial(a);
                     SkullMeta headM = (SkullMeta) head.getItemMeta();
                     headM = nms.setSkullOwner(ep.getEntity().getName(), headM);
-                    headM.setDisplayName(hpch.getDisplayName("player").replaceAll("\\{player}", ep.getEntity().getName()));
+                    headM.setDisplayName(hpch.getDisplayName("player").replace("{player}", ep.getEntity().getName()));
 
 
                     Location entityLoc = ep.getEntity().getLocation();
@@ -142,7 +157,9 @@ public class DeathEvents implements Listener {
 
                     List<String> strs = new ArrayList<>();
                     for (String str : hpch.getLore("player")) {
-                        strs.add(ChatColor.translateAlternateColorCodes('&', str.replaceAll("\\{player}", ep.getEntity().getName()).replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
+                        strs.add(ChatColor.translateAlternateColorCodes('&', str
+								.replace("{player}", ep.getEntity().getName())
+								.replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
                     }
                     headM.setLore(strs);
                     head.setItemMeta(headM);
@@ -155,7 +172,9 @@ public class DeathEvents implements Listener {
                     if (!event.isCancelled()) {
                         if (b && ep.getEntity().getKiller() != null) {
                             hp.getEconomy().withdrawPlayer(ep.getEntity(), lostprice);
-                            ep.getEntity().sendMessage(hp.getMessagesConfig().getString("lost-money").replaceAll("\\{player}", ep.getEntity().getKiller().getName()).replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price))));
+                            ep.getEntity().sendMessage(hp.getMessagesConfig().getString("lost-money")
+									.replace("{player}", ep.getEntity().getKiller().getName())
+									.replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price))));
                         }
                         world.dropItem(event.getLocation(), event.getSkull());
                     }
@@ -251,7 +270,9 @@ public class DeathEvents implements Listener {
                     List<String> strs = new ArrayList<>();
                     List<String> lore = hpch.getLore(fancyName);
                     for (String str2 : lore) {
-                        strs.add(ChatColor.translateAlternateColorCodes('&', str2.replaceAll("\\{type}", fancyName).replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
+                        strs.add(ChatColor.translateAlternateColorCodes('&', str2
+								.replace("{type}", fancyName)
+								.replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
                     }
                     sm.setLore(strs);
                     is.setItemMeta(sm);
@@ -299,7 +320,9 @@ public class DeathEvents implements Listener {
                 List<String> strs = new ArrayList<>();
                 List<String> lore = hpch.getLore(en);
                 for (String str2 : lore) {
-                    strs.add(ChatColor.translateAlternateColorCodes('&', str2.replaceAll("\\{type}", en).replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
+                    strs.add(ChatColor.translateAlternateColorCodes('&', str2
+							.replace("{type}", en)
+							.replaceAll("\\{price}", String.valueOf(HeadsPlus.getInstance().getConfiguration().fixBalanceStr(price)))));
                 }
                 sm.setLore(strs);
                 is.setItemMeta(sm);

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/DeathEvents.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/DeathEvents.java
@@ -100,7 +100,7 @@ public class DeathEvents implements Listener {
                     }
                 }
             } catch (Exception ex) {
-                new DebugPrint(ex, "Event (DeathEvents)", false, null);
+                DebugPrint.createReport(ex, "Event (DeathEvents)", false, null);
             }
         }
     }
@@ -181,7 +181,7 @@ public class DeathEvents implements Listener {
                 }
             }
         } catch (Exception e) {
-	        new DebugPrint(e, "Event (DeathEvents)", false, null);
+	        DebugPrint.createReport(e, "Event (DeathEvents)", false, null);
         }
 	}
 

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/HeadInteractEvent.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/HeadInteractEvent.java
@@ -70,7 +70,7 @@ public final class HeadInteractEvent implements Listener {
 		} catch (NullPointerException ex) {
 		//
 	    } catch (Exception e) {
-			new DebugPrint(e, "Event (HeadInteractEvent)", false, null);
+			DebugPrint.createReport(e, "Event (HeadInteractEvent)", false, null);
 		}
 	}
 	@SuppressWarnings("deprecation")

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/InventoryEvent.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/InventoryEvent.java
@@ -36,7 +36,7 @@ public class InventoryEvent implements Listener {
                 i.onClick(p, im, e);
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (InventoryInteractEvent)", false, null);
+            DebugPrint.createReport(ex, "Event (InventoryInteractEvent)", false, null);
         }
     }
 	
@@ -46,7 +46,7 @@ public class InventoryEvent implements Listener {
 			if(!(e.getPlayer() instanceof Player)) return;
 			InventoryManager.inventoryClosed((Player) e.getPlayer());
 		} catch (Exception ex) {
-            new DebugPrint(ex, "Event (InventoryCloseEvent)", false, null);
+            DebugPrint.createReport(ex, "Event (InventoryCloseEvent)", false, null);
         }
 	}
 }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardEvents.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardEvents.java
@@ -30,7 +30,7 @@ public class LeaderboardEvents implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (LeaderboardEvents)", false, null);
+            DebugPrint.createReport(ex, "Event (LeaderboardEvents)", false, null);
         }
 
     }
@@ -51,7 +51,7 @@ public class LeaderboardEvents implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (LeaderboardEvents)", false, null);
+            DebugPrint.createReport(ex, "Event (LeaderboardEvents)", false, null);
         }
 
     }
@@ -74,7 +74,7 @@ public class LeaderboardEvents implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (LeaderboardEvents)", false, null);
+            DebugPrint.createReport(ex, "Event (LeaderboardEvents)", false, null);
         }
     }
 
@@ -92,7 +92,7 @@ public class LeaderboardEvents implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (LeaderboardEvents)", false, null);
+            DebugPrint.createReport(ex, "Event (LeaderboardEvents)", false, null);
         }
     }
 }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlaceEvent.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlaceEvent.java
@@ -34,7 +34,7 @@ public class PlaceEvent implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (PlaceEvent)", false, null);
+            DebugPrint.createReport(ex, "Event (PlaceEvent)", false, null);
         }
     }
 }

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerDeathEvent.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerDeathEvent.java
@@ -32,7 +32,7 @@ public class PlayerDeathEvent implements Listener {
                 }
             }
         } catch (Exception ex) {
-            new DebugPrint(ex, "Event (PlayerDeathEvent, PlayerHeadDropEvent)", false, null);
+            DebugPrint.createReport(ex, "Event (PlayerDeathEvent, PlayerHeadDropEvent)", false, null);
         }
     }
 }


### PR DESCRIPTION
Treats 429 errors as a "try later" instead of a "stop now"

Minor edits: 
Cleaned up import everything * in death events (for various reasons should only use in special cases)
(not a huge issue, just some housework while I was testing something else)
Refactor DebugPrint to not require instantiating a new object just to run
