### PR TITLE
Cache new heads as to not continually re-add

### DIFF
--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/HeadsPlusConfigHeadsX.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/headsx/HeadsPlusConfigHeadsX.java
@@ -444,6 +444,7 @@ public class HeadsPlusConfigHeadsX extends ConfigSettings {
                 headsCache.put(key, getSkull(key));
             }
         }
+		allHeadsCache.add(texture);
         delaySave();
     }
 


### PR DESCRIPTION
Fixes autograbber adding a new head each time a new player since reload joins