### PR TITLE
fix missing materials from making plugin unusable

### DIFF
--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadInventory.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadInventory.java
@@ -249,7 +249,8 @@ public abstract class HeadInventory {
         if (itemIndex < list.size()) {
             is = list.get(itemIndex);
             ItemMeta im = is.getItemMeta();
-            im.setDisplayName(icon.getDisplayName().replace("{head-name}", is.getItemMeta().getDisplayName()));
+            if(is.getItemMeta().hasDisplayName())
+                im.setDisplayName(icon.getDisplayName().replace("{head-name}", is.getItemMeta().getDisplayName()));
             if (this instanceof SellheadMenu) {
                 im.setDisplayName(im.getDisplayName().replace("{default}",
                         HeadsPlus.getInstance().getHeadsConfig().getDisplayName(nbt.getType(is))));

--- a/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/Icon.java
+++ b/MAIN/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/Icon.java
@@ -78,7 +78,8 @@ public interface Icon {
     }
 
     default Material getMaterial() {
-        return Material.getMaterial(HeadsPlus.getInstance().getItems().getConfig().getString("icons." + getIconName() + ".material"));
+        Material material = Material.getMaterial(HeadsPlus.getInstance().getItems().getConfig().getString("icons." + getIconName() + ".material"));
+        return material != null ? material : Material.STONE;
     }
 
     default List<String> getLore() {


### PR DESCRIPTION
Copying config from 1.14 to 1.12 throws errors and won't open the gui - this at least shows a 'texture missing' for the gui backdrop instead of not letting players use it until the admin figures it out ;)