### PR TITLE
[WIP] Async head texture loading for Paper (fixes #38)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
@@ -190,12 +196,6 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.16.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <hp-project.version>v6.11.3-SNAPSHOT-1</hp-project.version>
-        <craftbukkit-directory>${user.home}\.m2\repository\org\bukkit\craftbukkit\</craftbukkit-directory>
-        <spigot-directory>${user.home}\.m2\repository\org\spigotmc\spigot\</spigot-directory>
+        <craftbukkit-directory>${user.home}${file.separator}.m2${file.separator}repository${file.separator}org${file.separator}bukkit${file.separator}craftbukkit${file.separator}</craftbukkit-directory>
+        <spigot-directory>${user.home}${file.separator}.m2${file.separator}repository${file.separator}org${file.separator}spigotmc${file.separator}spigot${file.separator}</spigot-directory>
     </properties>
 
     <build>
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -93,63 +93,63 @@
             <artifactId>craftbukkit-3</artifactId>
             <version>1.8-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.8-R0.1-SNAPSHOT\craftbukkit-1.8-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.8-R0.1-SNAPSHOT${file.separator}craftbukkit-1.8-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-2</artifactId>
             <version>1.8.3-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.8.3-R0.1-SNAPSHOT\craftbukkit-1.8.3-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.8.3-R0.1-SNAPSHOT${file.separator}craftbukkit-1.8.3-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-5</artifactId>
             <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.8.8-R0.1-SNAPSHOT\craftbukkit-1.8.8-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.8.8-R0.1-SNAPSHOT${file.separator}craftbukkit-1.8.8-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-4</artifactId>
             <version>1.9.2-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.9.2-R0.1-SNAPSHOT\craftbukkit-1.9.2-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.9.2-R0.1-SNAPSHOT${file.separator}craftbukkit-1.9.2-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-6</artifactId>
             <version>1.9.4-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.9.4-R0.1-SNAPSHOT\craftbukkit-1.9.4-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.9.4-R0.1-SNAPSHOT${file.separator}craftbukkit-1.9.4-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-7</artifactId>
             <version>1.10.2-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.10.2-R0.1-SNAPSHOT\craftbukkit-1.10.2-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.10.2-R0.1-SNAPSHOT${file.separator}craftbukkit-1.10.2-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-8</artifactId>
             <version>1.11.2-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.11.2-R0.1-SNAPSHOT\craftbukkit-1.11.2-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.11.2-R0.1-SNAPSHOT${file.separator}craftbukkit-1.11.2-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-10</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.13.2-R0.1-SNAPSHOT\craftbukkit-1.13.2-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.13.2-R0.1-SNAPSHOT${file.separator}craftbukkit-1.13.2-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-11</artifactId>
             <version>1.13-R0.1-SNAPSHOT-1</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.13-R0.1-SNAPSHOT\craftbukkit-1.13-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.13-R0.1-SNAPSHOT${file.separator}craftbukkit-1.13-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
@@ -162,14 +162,14 @@
             <artifactId>craftbukkit-12</artifactId>
             <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.14.4-R0.1-SNAPSHOT\craftbukkit-1.14.4-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.14.4-R0.1-SNAPSHOT${file.separator}craftbukkit-1.14.4-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit-1.15.1</artifactId>
             <version>1.15.1-R0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.15.1-R0.1-SNAPSHOT\craftbukkit-1.15.1-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.15.1-R0.1-SNAPSHOT${file.separator}craftbukkit-1.15.1-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <!-- Temporary -->
@@ -177,14 +177,14 @@
             <artifactId>craftbukkit-1.16.1</artifactId>
             <version>1.16.1-R0.1</version>
             <scope>system</scope>
-            <systemPath>${craftbukkit-directory}\1.16.1-R0.1-SNAPSHOT\craftbukkit-1.16.1-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${craftbukkit-directory}${file.separator}1.16.1-R0.1-SNAPSHOT${file.separator}craftbukkit-1.16.1-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-1.16.4</artifactId>
             <version>1.16.4-R0.1</version>
             <scope>system</scope>
-            <systemPath>${spigot-directory}\1.16.4-R0.1-SNAPSHOT\spigot-1.16.4-R0.1-SNAPSHOT.jar</systemPath>
+            <systemPath>${spigot-directory}${file.separator}1.16.4-R0.1-SNAPSHOT${file.separator}spigot-1.16.4-R0.1-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/src/main/java/io/github/thatsmusic99/headsplus/config/HeadsPlusConfigTextMenu.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/HeadsPlusConfigTextMenu.java
@@ -411,7 +411,7 @@ public class HeadsPlusConfigTextMenu extends ConfigSettings {
                         .replace("{header}", h.getConfig().getString("info.header"))
                         .replace("{author}", String.valueOf(hp.getAuthor()))
                         .replace("{locale}", hp.getConfiguration().getConfig().getString("locale"))
-                        .replaceAll("\\{contributors}", "Toldi, DariusTK, AlansS53, Gneiwny, steve4744, Niestrat99, Alexisparis007, jascotty2, Gurbiel, Mistermychciak, stashenko/The_stas, YouHaveTrouble, Tepoloco, Bieck_Smile"), sender));
+                        .replaceAll("\\{contributors}", "Toldi, DariusTK, AlansS53, Gneiwny, steve4744, Niestrat99, Alexisparis007, jascotty2, Gurbiel, Mistermychciak, stashenko/The_stas, YouHaveTrouble, Tepoloco, Bieck_Smile, PaulBGD"), sender));
             }
             return sb.toString();
         }

--- a/src/main/java/io/github/thatsmusic99/headsplus/config/HeadsPlusCrafting.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/HeadsPlusCrafting.java
@@ -22,8 +22,6 @@ public class HeadsPlusCrafting extends ConfigSettings {
 	
 	private void loadCrafting() {
 		getConfig().options().header("HeadsPlus by Thatsmusic99 - due to the way Bukkit works, this config can only be reloaded on restart.\nInstructions for setting up can be found at: https://github.com/Thatsmusic99/HeadsPlus/wiki");
-		getConfig().options().copyDefaults(true);
-		save();
 	}
 
 	@Override
@@ -31,6 +29,7 @@ public class HeadsPlusCrafting extends ConfigSettings {
 		performFileChecks();
 		loadCrafting();
 		checkCrafting();
+		getConfig().options().copyDefaults(true);
 		save();
 	}
 

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/HPPlayerDeathEvent.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/HPPlayerDeathEvent.java
@@ -82,11 +82,13 @@ public class HPPlayerDeathEvent extends HeadsPlusListener<PlayerDeathEvent> {
             PlayerHeadDropEvent phdEvent = new PlayerHeadDropEvent(victim, killer, head, location, amount);
             Bukkit.getPluginManager().callEvent(phdEvent);
             if (!phdEvent.isCancelled()) {
-                location.getWorld().dropItem(location, head.getItemStack());
                 if (lostprice > 0.0) {
                     economy.withdrawPlayer(victim, lostprice);
                     hp.getMessagesConfig().sendMessage("event.lost-money", victim, "{player}", killer.getName(), "{price}", hp.getConfiguration().fixBalanceStr(price));
                 }
+                head.getItemStackFuture().thenAccept(itemStack -> {
+                    location.getWorld().dropItem(location, itemStack);
+                });
             }
         }
     }

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/HPUtils.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/HPUtils.java
@@ -138,7 +138,7 @@ public class HPUtils {
         EntityHeadDropEvent event = new EntityHeadDropEvent(killer, head, location, EntityType.valueOf(id), amount);
         Bukkit.getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
-            location.getWorld().dropItem(location, head.getItemStack());
+            head.getItemStackFuture().thenAccept(itemStack -> location.getWorld().dropItem(location, itemStack));
         }
     }
 

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/paper/ActualPaperImpl.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/paper/ActualPaperImpl.java
@@ -3,11 +3,9 @@ package io.github.thatsmusic99.headsplus.util.paper;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import io.github.thatsmusic99.headsplus.HeadsPlus;
 import org.bukkit.Bukkit;
-import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.SkullMeta;
 
-import java.lang.reflect.Method;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -16,17 +14,6 @@ public class ActualPaperImpl implements PaperImpl {
 
     private static final Executor asyncExecutor = task -> Bukkit.getScheduler().runTaskAsynchronously(HeadsPlus.getInstance(), task);
     private static final Executor syncExecutor = task -> Bukkit.getScheduler().runTask(HeadsPlus.getInstance(), task);
-    private Method createProfile;
-    private Method setPlayerProfile;
-
-    {
-        try {
-            createProfile = Server.class.getMethod("createProfile", UUID.class, String.class);
-            setPlayerProfile = SkullMeta.class.getMethod("setPlayerProfile", PlayerProfile.class);
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-        }
-    }
 
     @Override
     public CompletableFuture<SkullMeta> setProfile(SkullMeta meta, String name) {
@@ -40,9 +27,9 @@ public class ActualPaperImpl implements PaperImpl {
             }
 
             try {
-                PlayerProfile profile = (PlayerProfile) createProfile.invoke(Bukkit.getServer(), uuid, name); // use reflection because of the million APIs provided for Server
+                PlayerProfile profile = Bukkit.getServer().createProfile(uuid, name);
                 profile.complete();
-                setPlayerProfile.invoke(meta, profile);
+                meta.setPlayerProfile(profile);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/paper/ActualPaperImpl.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/paper/ActualPaperImpl.java
@@ -1,0 +1,52 @@
+package io.github.thatsmusic99.headsplus.util.paper;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import io.github.thatsmusic99.headsplus.HeadsPlus;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public class ActualPaperImpl implements PaperImpl {
+
+    private static final Executor asyncExecutor = task -> Bukkit.getScheduler().runTaskAsynchronously(HeadsPlus.getInstance(), task);
+    private static final Executor syncExecutor = task -> Bukkit.getScheduler().runTask(HeadsPlus.getInstance(), task);
+    private Method createProfile;
+    private Method setPlayerProfile;
+
+    {
+        try {
+            createProfile = Server.class.getMethod("createProfile", UUID.class, String.class);
+            setPlayerProfile = SkullMeta.class.getMethod("setPlayerProfile", PlayerProfile.class);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public CompletableFuture<SkullMeta> setProfile(SkullMeta meta, String name) {
+        return CompletableFuture.supplyAsync(() -> {
+            UUID uuid;
+            Player player = Bukkit.getPlayer(name);
+            if (player != null) {
+                uuid = player.getUniqueId();
+            } else {
+                uuid = UUID.nameUUIDFromBytes(name.getBytes());
+            }
+
+            try {
+                PlayerProfile profile = (PlayerProfile) createProfile.invoke(Bukkit.getServer(), uuid, name); // use reflection because of the million APIs provided for Server
+                profile.complete();
+                setPlayerProfile.invoke(meta, profile);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return meta;
+        }, asyncExecutor).thenApplyAsync(sm -> sm, syncExecutor);
+    }
+}

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/paper/PaperImpl.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/paper/PaperImpl.java
@@ -1,0 +1,9 @@
+package io.github.thatsmusic99.headsplus.util.paper;
+
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface PaperImpl {
+    CompletableFuture<SkullMeta> setProfile(SkullMeta meta, String name);
+}

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/paper/PaperUtil.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/paper/PaperUtil.java
@@ -1,0 +1,36 @@
+package io.github.thatsmusic99.headsplus.util.paper;
+
+import io.github.thatsmusic99.headsplus.HeadsPlus;
+import io.papermc.lib.PaperLib;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+
+public class PaperUtil implements PaperImpl {
+
+    private final PaperImpl internalImpl;
+
+    public PaperUtil() {
+        PaperImpl impl;
+        if (PaperLib.isPaper()) {
+            try {
+                impl = new ActualPaperImpl();
+            } catch (Exception e) {
+                impl = null;
+                HeadsPlus.getInstance().getLogger().log(Level.WARNING, "Failed to initialize Paper integration", e);
+            }
+        } else {
+            impl = null;
+        }
+        internalImpl = impl;
+    }
+
+    public CompletableFuture<SkullMeta> setProfile(SkullMeta meta, String name) {
+        if (internalImpl == null) {
+            return CompletableFuture.completedFuture(HeadsPlus.getInstance().getNMS().setSkullOwner(name, meta));
+        }
+        return internalImpl.setProfile(meta, name);
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '6.11.3-SNAPSHOT-1'
 api-version: 1.13
 description: Spawns in heads with extra features.
 author: Thatsmusic99
-contributors: [DariusTK, Toldi, AlansS53, Gniewny, steve4744, Niestrat99, Alexisparis007, jascotty2, Gurbiel, Mistermychciak, Stashenko, Tepoloco, YouHaveTrouble, Bieck_Smile]
+contributors: [DariusTK, Toldi, AlansS53, Gniewny, steve4744, Niestrat99, Alexisparis007, jascotty2, Gurbiel, Mistermychciak, Stashenko, Tepoloco, YouHaveTrouble, Bieck_Smile, PaulBGD]
 website: 'https://www.spigotmc.org/resources/headsplus-1-8-x-1-15-x.40265/'
 # Please note this is mostly to let the weird messages from each plugin work.
 # Vault - Economy support


### PR DESCRIPTION
This also includes a POM fix for compiling on Linux, primarily fixing the file separators. If you'd like me to PR it separately I can.

The Paper util should only be loaded when Paper is present (via PaperLib) and fallback to sync when unavailable.
In theory the `getItemStackFuture()` could be used in other places, but I think this is the only place where the server forces the textures to load first.

This is marked as a work in progress until @cloakfox (no relation) tests it, given he had the original issue.