### PR TITLE
Head packs

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/HeadsPlus.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/HeadsPlus.java
@@ -8,6 +8,7 @@ import io.github.thatsmusic99.headsplus.commands.maincommand.lists.blacklist.*;
 import io.github.thatsmusic99.headsplus.commands.maincommand.lists.whitelist.*;
 import io.github.thatsmusic99.headsplus.config.*;
 import io.github.thatsmusic99.headsplus.config.challenges.HeadsPlusChallenges;
+import io.github.thatsmusic99.headsplus.config.customheads.HeadPackLoader;
 import io.github.thatsmusic99.headsplus.config.customheads.HeadsPlusConfigCustomHeads;
 import io.github.thatsmusic99.headsplus.crafting.RecipePerms;
 import io.github.thatsmusic99.headsplus.inventories.InventoryManager;
@@ -342,6 +343,7 @@ public class HeadsPlus extends JavaPlugin {
         cs.add(hpch);
         hpchx = new HeadsPlusConfigCustomHeads();
         cs.add(hpchx);
+        HeadPackLoader.init();
         hpcr = new HeadsPlusCrafting();
         cs.add(hpcr);
         hpchl = new HeadsPlusChallenges();

--- a/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadPackLoader.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadPackLoader.java
@@ -1,0 +1,57 @@
+package io.github.thatsmusic99.headsplus.config.customheads;
+
+import io.github.thatsmusic99.headsplus.HeadsPlus;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HeadPackLoader {
+
+    private static List<String> registeredSections = new ArrayList<>();
+    private static List<String> downloadedFiles = new ArrayList<>();
+
+    public static void init() {
+        File packs = new File(HeadsPlus.getInstance().getDataFolder(), "packs");
+        if (!packs.exists()) packs.mkdirs();
+        if (packs.listFiles() == null) return;
+        for (File packFile : packs.listFiles()) {
+            try {
+                downloadedFiles.add(packFile.getName());
+                String fileName = packFile.getName().substring(0, packFile.getName().lastIndexOf('.'));
+                JSONObject object = (JSONObject) new JSONParser().parse(new FileReader(packFile));
+                JSONObject details = (JSONObject) object.get("details");
+                if ((boolean) details.get("enabled")) {
+                    // Heads inside the section
+                    List<String> headList = new ArrayList<>();
+                    HeadsPlus.getInstance().getLogger().info("Hooked into " + fileName + "!");
+                    registeredSections.add(fileName);
+                    JSONObject heads = (JSONObject) object.get("heads");
+                    for (Object headObj : heads.keySet()) {
+                        String head = (String) headObj;
+                        JSONObject headInfo = (JSONObject) heads.get(head);
+                        headList.add(head);
+                        HeadsPlus.getInstance().getHeadsXConfig().headsCache.put(head,
+                                HeadsPlus.getInstance().getHeadsXConfig().getSkullFromTexture((String) headInfo.get("texture"), (String) headInfo.get("display-name")));
+                        System.out.println("Added " + head);
+                    }
+
+                    HeadsPlus.getInstance().getHeadsXConfig().sections.put(fileName, headList);
+                    HeadsPlus.getInstance().getHeadsXConfig().sectionsCache.put(fileName,
+                            new HeadsPlusConfigCustomHeads.SectionInfo(fileName,
+                                    (String) details.get("display-name"),
+                                    (String) details.get("texture"),
+                                    (String) details.get("permission"),true));
+                }
+            } catch (IOException | ParseException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadsPlusConfigCustomHeads.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/customheads/HeadsPlusConfigCustomHeads.java
@@ -185,10 +185,10 @@ public class HeadsPlusConfigCustomHeads extends ConfigSettings {
     }
 
     @Nullable
-    public ItemStack getSkull(String s) {
+    public ItemStack getSkull(@NotNull String s) {
         try {
             final String key = s.contains("#") ? s.split("#")[1] : s;
-            ItemStack is = headsCache.get(s);
+            ItemStack is = headsCache.get(key);
             // todo? allow loading texture directly from parameter if matches base64 pattern?
             return is != null ? is.clone() : getSkullFromTexture(
                     getConfig().getString("heads." + key + ".texture"),

--- a/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHead.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHead.java
@@ -22,8 +22,12 @@ public class CustomHead extends Content {
     private String id;
 
     public CustomHead(String id) {
+        this(id, hp.getHeadsXConfig().getPrice(id));
+    }
+
+    public CustomHead(String id, double price) {
         super(hp.getHeadsXConfig().getSkull(id));
-        this.price = hp.getHeadsXConfig().getPrice(id);
+        this.price = price;
         this.id = id;
     }
 

--- a/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHeadSection.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHeadSection.java
@@ -30,6 +30,7 @@ public class CustomHeadSection extends Content {
 
     @Override
     public boolean onClick(Player player, InventoryClickEvent event) {
+        if (!player.hasPermission(section.getPermission())) return false;
         HashMap<String, String> context = new HashMap<>();
         context.put("section", section.getName());
         InventoryManager manager = InventoryManager.getManager(player);

--- a/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHeadSection.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/inventories/icons/content/CustomHeadSection.java
@@ -1,20 +1,29 @@
 package io.github.thatsmusic99.headsplus.inventories.icons.content;
 
+import io.github.thatsmusic99.headsplus.HeadsPlus;
 import io.github.thatsmusic99.headsplus.api.events.SectionChangeEvent;
+import io.github.thatsmusic99.headsplus.config.customheads.HeadsPlusConfigCustomHeads;
 import io.github.thatsmusic99.headsplus.inventories.InventoryManager;
 import io.github.thatsmusic99.headsplus.inventories.icons.Content;
+import io.github.thatsmusic99.headsplus.reflection.NBTManager;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class CustomHeadSection extends Content {
-    private String section;
-    public CustomHeadSection(ItemStack itemStack, String section) {
-        super(itemStack);
-        this.section = section;
+    private HeadsPlusConfigCustomHeads.SectionInfo section;
+
+    public CustomHeadSection(HeadsPlusConfigCustomHeads.SectionInfo info) {
+        super(HeadsPlus.getInstance().getHeadsXConfig().getSkull(info.getTexture()));
+        this.section = info;
     }
 
     public CustomHeadSection() {}
@@ -22,9 +31,9 @@ public class CustomHeadSection extends Content {
     @Override
     public boolean onClick(Player player, InventoryClickEvent event) {
         HashMap<String, String> context = new HashMap<>();
-        context.put("section", section);
+        context.put("section", section.getName());
         InventoryManager manager = InventoryManager.getManager(player);
-        SectionChangeEvent changeEvent = new SectionChangeEvent(player, manager.getSection(), section);
+        SectionChangeEvent changeEvent = new SectionChangeEvent(player, manager.getSection(), section.getName());
         Bukkit.getPluginManager().callEvent(changeEvent);
         if (!changeEvent.isCancelled()) {
             InventoryManager.getManager(player).open(InventoryManager.InventoryType.HEADS_CATEGORY, context);
@@ -32,7 +41,28 @@ public class CustomHeadSection extends Content {
         }
         // The event was cancelled, so don't destroy the GUI
         return false;
+    }
 
+    @Override
+    public void initNameAndLore(String id, Player player) {
+        ItemMeta meta = item.getItemMeta();
+        ConfigurationSection itemSec = hpi.getConfigurationSection("icons.headsection");
+        if (meta != null) {
+            try {
+                meta.setDisplayName(hpc.formatMsg(itemSec.getString("display-name")
+                        .replaceAll("\\{head-name}", section.getDisplayName()), player));
+                List<String> lore = new ArrayList<>();
+                for (String loreStr : itemSec.getStringList("lore")) {
+                    lore.add(hpc.formatMsg(loreStr, player)
+                            .replaceAll("\\{head-count}", String.valueOf(hp.getHeadsXConfig().sections.get(section.getName()).size())));
+                }
+                meta.setLore(lore);
+            } catch (NullPointerException ex) {
+                hp.getLogger().warning("A problem was found when setting the display name for icon Heads Section with ID " + section + ". Either the item is null, or there is a config error in the display names! (Error code: 11)");
+
+            }
+            item.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/io/github/thatsmusic99/headsplus/inventories/list/HeadsMenu.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/inventories/list/HeadsMenu.java
@@ -5,6 +5,7 @@ import io.github.thatsmusic99.headsplus.config.customheads.HeadsPlusConfigCustom
 import io.github.thatsmusic99.headsplus.inventories.BaseInventory;
 import io.github.thatsmusic99.headsplus.inventories.icons.Content;
 import io.github.thatsmusic99.headsplus.inventories.icons.content.CustomHeadSection;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -46,36 +47,18 @@ public class HeadsMenu extends BaseInventory {
     public List<Content> transformContents(HashMap<String, String> context, Player player) {
         List<Content> contents = new ArrayList<>();
         HeadsPlusConfigCustomHeads headsConfig = HeadsPlus.getInstance().getHeadsXConfig();
-        for (String section : headsConfig.sections.keySet()) {
-            ConfigurationSection configSec = headsConfig.getConfig().getConfigurationSection("sections." + section);
-            ConfigurationSection itemSec = hpi.getConfigurationSection("icons.headsection");
-            ItemStack item;
-            try {
-                item = headsConfig.getSkull(configSec.getString("texture"));
-            } catch (NullPointerException ex) {
-                if (!suppressWarnings) {
-                    hp.getLogger().warning("Texture for " + configSec.getString("texture") + " not found. (Error code: 10)");
+        for (HeadsPlusConfigCustomHeads.SectionInfo section : headsConfig.sectionsCache.values()) {
+            if (section.isEnabled()) {
+                try {
+                    CustomHeadSection section1 = new CustomHeadSection(section);
+                    if (section1.getItemStack() == null || section1.getItemStack().getType() == Material.AIR) continue;
+                    section1.initNameAndLore(null, player);
+                    contents.add(section1);
+                } catch (NullPointerException ignored) {
+                    ignored.printStackTrace();
                 }
-                continue;
-            }
-            SkullMeta meta = (SkullMeta) item.getItemMeta();
-            try {
-                meta.setDisplayName(hpc.formatMsg(itemSec.getString("display-name")
-                        .replaceAll("\\{head-name}", configSec.getString("display-name")), player));
-                List<String> lore = new ArrayList<>();
-                for (String loreStr : itemSec.getStringList("lore")) {
-                    lore.add(hpc.formatMsg(loreStr, player)
-                            .replaceAll("\\{head-count}", String.valueOf(headsConfig.sections.get(section).size())));
-                }
-                meta.setLore(lore);
-            } catch (NullPointerException ex) {
-                if (!suppressWarnings) {
-                    hp.getLogger().warning("A problem was found when setting the display name for icon Heads Section with ID " + section + ". Either the item is null, or there is a config error in the display names! (Error code: 11)");
-                }
-            }
 
-            item.setItemMeta(meta);
-            contents.add(new CustomHeadSection(item, section));
+            }
         }
         return contents;
     }

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/CachedValues.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/CachedValues.java
@@ -10,8 +10,10 @@ public class CachedValues {
     public static final Pattern PLAYER_NAME = Pattern.compile("^([a-zA-Z_0-9]){3,16}$");
     public static final Pattern DOUBLE_PATTERN = Pattern.compile("^[0-9]+(\\.[0-9]+)?$");
     public static final Pattern MINECRAFT_TEXTURES_PATTERN = Pattern.compile("^(http(s)?://)?textures\\.minecraft\\.net/texture/([0-9a-fA-F])+$");
-    public static final Pattern BASE64_PATTERN = Pattern.compile("^(eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUv)[a-zA-Z0-9]+=*$");
+    public static final Pattern BASE64_PATTERN = Pattern.compile("^[a-zA-Z0-9]+=*$");
     public static final Pattern CONTENT_PATTERN = Pattern.compile("(C)");
+    public static final Pattern HASH_PATTERN = Pattern.compile("^[a-fA-f0-9]+$");
+    public static final Pattern MINECRAFT_EDUCATION_PATTERN = Pattern.compile("^(http(s)?://)?education\\.minecraft\\.net/wp-content/uploads/(.)+$");
 
     public static Double getPrice(String path, FileConfiguration config) {
         String value = config.getString(path);


### PR DESCRIPTION
Head packs are a feature I previously brainstormed in mid-2019, however, I believe were scrapped for reasons I personally don't recall. Although, now I have the basic framework to make them a possible feature for the much-delayed v7 update, which overhauls a lot of HeadsPlus's major features; this is just scratching the surface.

In addition to this, this will be the first feature of HeadsPlus to provide full support for HD/transparent heads.

These packs are fetched from a repo (currently `Thatsmusic99/HeadsPlusHeadPacks`, which will be made public in the future) and downloaded locally so they can easily be enabled and disabled whenever. By default, all packs are disabled and must be in a set format. If they are not in a set format when submitted, changes must be requested, and only I will be able to make changes to said packs on demand. If the user modifies the pack format resulting in it not being readable, a warning is sent and then the entire pack is ignored by the plugin until prompted to be checked again through `/hp reload` or `/hp pack enable/disable`. When the head pack is loaded, all heads are loaded even if the section is disabled, meaning those heads can be used in mob drops and crafting.

As of currently, the following criteria still need to be met:
- [ ] Create contributing guidelines for `Thatsmusic99/HeadsPlusHeadPacks`
- [ ] Allow the plugin to download packs from the repo as soon as it is open
- [ ] Create the `/hp pack` subcommand. Since the configuration is getting reworked in v7 as well, messages will all be placeholders.
- [ ] Add head textures to the allHeadsCache.
- [ ] Make heads from their packs allow custom prices, including a default price for the pack.
- [ ] Allow the possibility for a donation option so users can donate to head pack authors.
- [ ] Set up proper validation so the plugin doesn't completely die when something isn't quite right.

